### PR TITLE
Add public type constants to tesseract sys

### DIFF
--- a/tesseract-sys/build.rs
+++ b/tesseract-sys/build.rs
@@ -11,10 +11,10 @@ fn main() {
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
-    let bindings = bindgen::Builder::default()
+    let capi_bindings = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
-        .header("wrapper.h")
+        .header("wrapper_capi.h")
         .whitelist_function("^Tess.*")
         .blacklist_type("Boxa")
         .blacklist_type("Pix")
@@ -26,11 +26,21 @@ fn main() {
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.
-        .expect("Unable to generate bindings");
+        .expect("Unable to generate capi bindings");
+
+    let public_types_bindings = bindgen::Builder::default()
+        .header("wrapper_public_types.hpp")
+        .whitelist_var("^k.*")
+        .blacklist_item("kPolyBlockNames")
+        .generate()
+        .expect("Unable to generate public types bindings");
 
     // Write the bindings to the $OUT_DIR/bindings.rs file.
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("Couldn't write bindings!");
+    capi_bindings
+        .write_to_file(out_path.join("capi_bindings.rs"))
+        .expect("Couldn't write capi bindings!");
+    public_types_bindings
+        .write_to_file(out_path.join("public_types_bindings.rs"))
+        .expect("Couldn't write public types bindings!");
 }

--- a/tesseract-sys/src/lib.rs
+++ b/tesseract-sys/src/lib.rs
@@ -4,7 +4,8 @@
 
 use leptonica_sys::{Boxa, Pix, Pixa, _IO_FILE};
 
-include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+include!(concat!(env!("OUT_DIR"), "/capi_bindings.rs"));
+include!(concat!(env!("OUT_DIR"), "/public_types_bindings.rs"));
 
 #[cfg(test)]
 mod tests {
@@ -30,5 +31,12 @@ mod tests {
             pixFreeData(image);
             TessBaseAPIDelete(cube);
         }
+    }
+
+    #[test]
+    #[allow(path_statements)]
+    fn defined_constants() {
+        kMinCredibleResolution;
+        kMaxCredibleResolution;
     }
 }

--- a/tesseract-sys/wrapper.h
+++ b/tesseract-sys/wrapper.h
@@ -1,1 +1,0 @@
-#include <tesseract/capi.h>

--- a/tesseract-sys/wrapper_capi.h
+++ b/tesseract-sys/wrapper_capi.h
@@ -1,0 +1,1 @@
+#include <tesseract/capi.h>

--- a/tesseract-sys/wrapper_public_types.hpp
+++ b/tesseract-sys/wrapper_public_types.hpp
@@ -1,0 +1,1 @@
+#include <tesseract/publictypes.h>


### PR DESCRIPTION
@timvisee requested kMinCredibleResolution and kMaxCredibleResolution.
This required importing as a cpp header. It conflicted with capi.h (they
had some enumeration keys in common) so it needed splitting into a new binding.

https://github.com/antimatter15/tesseract-rs/issues/8