### PR TITLE
Bump tesseract-sys, leptonica-sys deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ keywords      = ["tesseract", "OCR", "bindings"]
 categories    = ["api-bindings", "multimedia::images"]
 
 [dependencies]
-leptonica-sys = "0.3.0"
-tesseract-sys = "0.5.1"
+leptonica-sys = "0.3.2"
+tesseract-sys = "0.5.3"
 thiserror = "1.0"

--- a/src/plumbing/pix.rs
+++ b/src/plumbing/pix.rs
@@ -48,7 +48,12 @@ impl Pix {
     ///
     /// Read an image from memory
     pub fn read_mem(img: &[u8]) -> Result<Self, PixReadMemError> {
-        let ptr = unsafe { pixReadMem(img.as_ptr(), img.len()) };
+        let img_len: u64 = img
+            .len()
+            .try_into()
+            .expect("Image len usize doesn't fit in u64");
+
+        let ptr = unsafe { pixReadMem(img.as_ptr(), img_len) };
         if ptr.is_null() {
             Err(PixReadMemError {})
         } else {


### PR DESCRIPTION
depends on:
* https://github.com/ccouzens/leptonica-sys/pull/5
* https://github.com/ccouzens/tesseract-sys/pull/2

I'm getting clang version conflicts when adding tesseract-rs as a dependency to my project, another one of my dependencies uses a new version of bindgen which in turn uses a newer version of clang.

Going through the process of updating all of tesseracts dependencies so that these two dependencies can co-exist in my project.