### PR TITLE
Add new_with_oem constructor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -271,3 +271,14 @@ fn oem_test() -> Result<(), TesseractError> {
     assert_ne!(only_tesseract_str, only_lstm_str);
     Ok(())
 }
+
+#[test]
+fn oem_ltsm_only_test() -> Result<(), TesseractError> {
+    let only_lstm_str = Tesseract::new_with_oem(None, Some("eng"), OcrEngineMode::LstmOnly)?
+        .set_image("img.png")?
+        .recognize()?
+        .get_text()?;
+
+    assert_eq!(only_lstm_str, include_str!("../img.txt"));
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate tesseract_sys;
 extern crate thiserror;
 
 use self::thiserror::Error;
@@ -5,6 +6,11 @@ use std::ffi::CString;
 use std::ffi::NulError;
 use std::os::raw::c_int;
 use std::str;
+
+use self::tesseract_sys::{
+    TessOcrEngineMode, TessOcrEngineMode_OEM_DEFAULT, TessOcrEngineMode_OEM_LSTM_ONLY,
+    TessOcrEngineMode_OEM_TESSERACT_LSTM_COMBINED, TessOcrEngineMode_OEM_TESSERACT_ONLY,
+};
 
 pub mod plumbing;
 
@@ -60,14 +66,12 @@ pub enum OcrEngineMode {
 }
 
 impl OcrEngineMode {
-    pub(crate) fn to_value(&self) -> plumbing::TessOcrEngineMode {
+    fn to_value(&self) -> TessOcrEngineMode {
         match *self {
-            OcrEngineMode::Default => plumbing::TessOcrEngineMode_OEM_DEFAULT,
-            OcrEngineMode::LstmOnly => plumbing::TessOcrEngineMode_OEM_LSTM_ONLY,
-            OcrEngineMode::TesseractLstmCombined => {
-                plumbing::TessOcrEngineMode_OEM_TESSERACT_LSTM_COMBINED
-            }
-            OcrEngineMode::TesseractOnly => plumbing::TessOcrEngineMode_OEM_TESSERACT_ONLY,
+            OcrEngineMode::Default => TessOcrEngineMode_OEM_DEFAULT,
+            OcrEngineMode::LstmOnly => TessOcrEngineMode_OEM_LSTM_ONLY,
+            OcrEngineMode::TesseractLstmCombined => TessOcrEngineMode_OEM_TESSERACT_LSTM_COMBINED,
+            OcrEngineMode::TesseractOnly => TessOcrEngineMode_OEM_TESSERACT_ONLY,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,7 @@ fn hocr_test() -> Result<(), TesseractError> {
 }
 
 #[test]
+#[ignore] // Many systems do not have legacy Tesseract data available
 fn oem_test() -> Result<(), TesseractError> {
     let only_tesseract_str =
         Tesseract::new_with_oem(None, Some("eng"), OcrEngineMode::TesseractOnly)?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,23 @@ pub enum TesseractError {
     SetVariableError(#[from] SetVariableError),
 }
 
+/// https://tesseract-ocr.github.io/tessapi/5.x/a01818.html#a04550a0ed1279562027bf2fc92c421aead84e1ef94e50df1622b4fcd189c6c00b
 pub enum OcrEngineMode {
+    /// Run Tesseract only - fastest; deprecated
     Default,
+    /// Run just the LSTM line recognizer.
     LstmOnly,
+    /// Run the LSTM recognizer, but allow fallback
+    /// to Tesseract when things get difficult.
+    /// deprecated
     TesseractLstmCombined,
+    /// Specify this mode,
+    /// to indicate that any of the above modes
+    /// should be automatically inferred from the
+    /// variables in the language-specific config,
+    /// command-line configs, or if not specified
+    /// in any of the above should be set to the
+    /// default OEM_TESSERACT_ONLY.
     TesseractOnly,
 }
 

--- a/src/plumbing/mod.rs
+++ b/src/plumbing/mod.rs
@@ -19,6 +19,11 @@ pub use self::tess_base_api::TessBaseAPISetImageSafetyError;
 pub use self::tess_base_api::TessBaseAPISetVariableError;
 pub use self::tesseract_text::TesseractText;
 
+pub use self::tesseract_text::{
+    TessOcrEngineMode, TessOcrEngineMode_OEM_DEFAULT, TessOcrEngineMode_OEM_LSTM_ONLY,
+    TessOcrEngineMode_OEM_TESSERACT_LSTM_COMBINED, TessOcrEngineMode_OEM_TESSERACT_ONLY,
+};
+
 #[test]
 fn ocr_from_mem_with_ppi() -> Result<(), Box<dyn std::error::Error>> {
     use std::ffi::CString;

--- a/src/plumbing/tess_base_api.rs
+++ b/src/plumbing/tess_base_api.rs
@@ -3,11 +3,11 @@ extern crate thiserror;
 
 use self::tesseract_sys::{
     TessBaseAPICreate, TessBaseAPIDelete, TessBaseAPIGetHOCRText, TessBaseAPIGetUTF8Text,
-    TessBaseAPIInit3, TessBaseAPIRecognize, TessBaseAPISetImage, TessBaseAPISetImage2,
-    TessBaseAPISetSourceResolution, TessBaseAPISetVariable,
+    TessBaseAPIInit2, TessBaseAPIInit3, TessBaseAPIRecognize, TessBaseAPISetImage,
+    TessBaseAPISetImage2, TessBaseAPISetSourceResolution, TessBaseAPISetVariable,
 };
 use self::thiserror::Error;
-use crate::plumbing::{Pix, TesseractText};
+use crate::plumbing::{Pix, TessOcrEngineMode, TesseractText};
 use std::convert::TryInto;
 use std::ffi::CStr;
 use std::os::raw::c_int;
@@ -77,6 +77,31 @@ impl TessBaseAPI {
                 self.0,
                 datapath.map(CStr::as_ptr).unwrap_or_else(ptr::null),
                 language.map(CStr::as_ptr).unwrap_or_else(ptr::null),
+            )
+        };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(TessBaseAPIInitError {})
+        }
+    }
+
+    /// Wrapper for [`Init-4`](https://tesseract-ocr.github.io/tessapi/5.x/a02438.html#a6d0956a66158ead4e3a86c7f50dad56e)
+    /// and [`TessBaseAPIInit2`](https://tesseract-ocr.github.io/tessapi/5.x/a00008.html#a07dd1bc35798164fa528134e78fbfe49)
+    ///
+    /// Start tesseract
+    pub fn init_4(
+        &mut self,
+        datapath: Option<&CStr>,
+        language: Option<&CStr>,
+        oem: TessOcrEngineMode,
+    ) -> Result<(), TessBaseAPIInitError> {
+        let ret = unsafe {
+            TessBaseAPIInit2(
+                self.0,
+                datapath.map(CStr::as_ptr).unwrap_or_else(ptr::null),
+                language.map(CStr::as_ptr).unwrap_or_else(ptr::null),
+                oem,
             )
         };
         if ret == 0 {

--- a/src/plumbing/tesseract_text.rs
+++ b/src/plumbing/tesseract_text.rs
@@ -5,6 +5,11 @@ use std::convert::AsRef;
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+pub use self::tesseract_sys::{
+    TessOcrEngineMode, TessOcrEngineMode_OEM_DEFAULT, TessOcrEngineMode_OEM_LSTM_ONLY,
+    TessOcrEngineMode_OEM_TESSERACT_LSTM_COMBINED, TessOcrEngineMode_OEM_TESSERACT_ONLY,
+};
+
 /// Wrapper around Tesseract's returned strings
 pub struct TesseractText(*mut c_char);
 


### PR DESCRIPTION
Added a new constructor to be able to define the OCR engine mode to use.

For that, I wrapped the `TessBaseAPIInit2()` method and created a public surface enum wrapping the OEM constants from `tesseract_sys`.

But I'm not quite sure if using `pub use` [here](https://github.com/antimatter15/tesseract-rs/compare/master...Moerfi666:master#diff-9664ebbcc1811f070a6430f385f7e7fa172225e12cba61fcaa30a840ef1f7705R22) is the correct way here.
