### PR TITLE
Adds set_rectangle() method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,6 +154,11 @@ impl Tesseract {
         Ok(self)
     }
 
+    pub fn set_rectangle(mut self, left: i32, top: i32, width: i32, height: i32) -> Self {
+        self.0.set_rectangle(left, top, width, height);
+        self
+    }
+
     pub fn set_source_resolution(mut self, ppi: i32) -> Self {
         self.0.set_source_resolution(ppi);
         self


### PR DESCRIPTION
I've needed to use the `SetRectangle()` function (https://tesseract-ocr.github.io/tessapi/4.0.0/a01625.html#ga284228c7e9d18bbbd3984d44e252d625) and saw that the plumbing already exposes it as `set_rectangle()` and added a corresponding method to `Tesseract`.

I've re-built the crate and the call works for me.