### PR TITLE
Add wrapper for init_1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,22 @@ impl Tesseract {
         Ok(tess)
     }
 
+    pub fn new_with_data(
+        data: &[u8],
+        language: Option<&str>,
+        oem: OcrEngineMode,
+    ) -> Result<Self, InitializeError> {
+        let mut tess = Tesseract(plumbing::TessBaseApi::create());
+        let language = match language {
+            Some(i) => Some(CString::new(i)?),
+            None => None,
+        };
+
+        tess.0
+            .init_1(data, language.as_deref(), oem.to_value())?;
+        Ok(tess)
+    }
+
     pub fn set_image(mut self, filename: &str) -> Result<Self, SetImageError> {
         let pix = plumbing::leptonica_plumbing::Pix::read(&CString::new(filename)?)?;
         self.0.set_image_2(&pix);


### PR DESCRIPTION
This will allow to init Tesseract with in-memory stored trained data.
Corresponding PR in https://github.com/ccouzens/tesseract-plumbing/pull/5.
Fixes https://github.com/antimatter15/tesseract-rs/issues/28