### PR TITLE
feat: :arrow_up: bump tesseract-plumbing to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ categories    = ["api-bindings", "multimedia::images"]
 
 [dependencies]
 tesseract-sys = "~0.5"
-tesseract-plumbing = "~0.10"
+tesseract-plumbing = "~0.11"
 thiserror = "1.0"


### PR DESCRIPTION
`tesseract-plumbing` got an optional feature that can be turned off to allow older installations of the tessearct lib. By default, everything only works with libtesseract 5.2 or higher.

The changes that lead to `tesseract-plumbing` can be seen here: https://github.com/ccouzens/tesseract-plumbing/commit/5c8b3df68d1b6343effa48cfbe4321256f0fafb1

No breaking changes are introduced here as per default, the new feature is enabled and the API of `tesseract-plumbing` is identical to the 0.10 version.