### PR TITLE
Run CI without default features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,8 @@ jobs:
       run: sudo apt-get install libleptonica-dev libtesseract-dev clang tesseract-ocr-eng
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --no-default-features
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --no-default-features
     - name: Check formatting
       run: cargo fmt -- --check


### PR DESCRIPTION
As the test environment doesn't have tesseract-5.2

@philsuess 's recent change https://github.com/antimatter15/tesseract-rs/pull/41enables us to disable the cutting edge parts of tesseract.

We were seeing issues like this https://github.com/antimatter15/tesseract-rs/actions/runs/4854598122/jobs/8652164531

```
error[E0432]: unresolved import `self::tesseract_sys::TessBaseAPIInit5`
 --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/tesseract-plumbing-0.10.0/src/tess_base_api.rs:9:5
  |
9 |     TessBaseAPIInit5, TessBaseAPIMeanTextConf, TessBaseAPIRecognize, TessBaseAPISetImage,
  |     ^^^^^^^^^^^^^^^^
  |     |
  |     no `TessBaseAPIInit5` in the root
  |     help: a similar name exists in the module: `TessBaseAPIInit1`
```