### PR TITLE
Update tesseract-sys to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords      = ["tesseract", "OCR", "bindings"]
 categories    = ["api-bindings", "multimedia::images"]
 
 [dependencies]
-tesseract-sys = "~0.5"
+tesseract-sys = "~0.6"
 tesseract-plumbing = { version="~0.11", default-features = false }
 thiserror = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories    = ["api-bindings", "multimedia::images"]
 
 [dependencies]
 tesseract-sys = "~0.6"
-tesseract-plumbing = { version="~0.11", default-features = false }
+tesseract-plumbing = { version="~0.11.1", default-features = false }
 thiserror = "1.0"
 
 [features]


### PR DESCRIPTION
`tesseract-plumbing` since 0.11.1  depends on `tesseract-sys` 0.6. This PR just propagates that dependency update to this crate.